### PR TITLE
Fixes #3

### DIFF
--- a/src/xhr-polyfill.js
+++ b/src/xhr-polyfill.js
@@ -337,7 +337,7 @@ DelegateHandler.prototype.send = function() {
   reqContext.requestData = undefined
 
   // returns a native FormData from the plugin's polyfill
-  if (FormData.prototype.isPrototypeOf(requestData))
+  if (FormData.prototype.isPrototypeOf(requestData) && requestData.__getNative && Function.prototype.isPrototypeOf(requestData.__getNative))
     requestData = requestData.__getNative()
 
   delegate.send(requestData)


### PR DESCRIPTION
Fixes #3 when the __getNative function does not exist on the FormData object.